### PR TITLE
Create separate speaker pages

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -28,6 +28,17 @@
 # proxy "/this-page-has-no-template.html", "/template-file.html", :locals => {
 #  :which_fake_page => "Rendering a fake page with a local variable" }
 
+data.previous_speakers.each do |conference|
+  conference[:speakers].each do |speaker|
+    slug = speaker[:name].downcase.gsub(/\s+/, '-')
+
+    proxy "/previous-speakers/#{conference[:year]}/#{slug}",
+      "/individual_speaker.html",
+      locals: { speaker: speaker },
+      ignore: true
+  end
+end
+
 ###
 # Helpers
 ###

--- a/data/previous_speakers.yml
+++ b/data/previous_speakers.yml
@@ -1,247 +1,249 @@
 ---
-- name: "Al Nelson"
-  headshot: "al-nelson.png"
-  title: "What Roleplaying Games Can Teach Us About Open Source Communities"
-  bio:
-    "Al Nelson is a writer of both code and words and finds joy in combining the two. They write documentation for Alpine Data Labs by day and tell stories through novels and games by night."
-  abstract:
-    "In games, a valuable team is made up of characters with varied talents and skills. They need to be adaptable, to communicate, and most of all, to work together. As a team, they can accomplish even the most intimidating quests. It's time we took this mentality to the open source community.
-    </p><p>
-    Roleplaying games can teach us a lot about diversity and working as a team if we dig a little deeper. In such games, players take on the role of a fantasy character and participate in quests and adventures with a group of other players. During this talk, I will take popular fantasy classes and relate them to the variety of people who contribute to open source communities every day.
-    </p><p>
-    Just like a roleplaying party would fail with only type of character, open source needs the unsung heroes: the technical writers, the artists, the testers—to make the project a reality. By building our 'party' around diverse interests and welcoming newcomers with open arms, open source communities can prosper."
-  handle: "musegarden"
-  video_url: "https://www.youtube.com/watch?v=Yk57XV_bbPY"
-- name: "Alex Harms"
-  headshot: "alex-harms.jpg"
-  title: "Learning to Empathy"
-  bio:
-    "Alex Harms helps teams thrive by encouraging mindfulness and facilitating trust and openness. The result is improved communication, better technical decisions, and renewed joy in their working environment and codebase."
-  abstract:
-    "You've heard empathy is a learned skill. Let's really talk about it. What does it mean to have empathy? Why does it matter, anyway? And if empathy is useful (I hope to show you how it is), how do you get better at it?
-    </p><p>
-    In this session, you'll learn real stuff about what's in your own heart, and how to connect to the people you encounter. Less feeling shitty, more enjoying projects!"
-  video_url: "https://www.youtube.com/watch?v=U15nkcSY2GI"
-- name: "Audrey Eschright"
-  headshot: "audrey-eschright.jpg"
-  title: "Enforcing Your Code of Conduct: Effective Incident Response"
-  bio:
-    "Audrey Eschright is a software developer, community organizer, and activist based in Portland, OR. She produces The Recompiler, a feminist hacker magazine; founded Calagator, an open source community calendaring service; and co-founded Open Source Bridge, an annual conference for open source citizens."
-  abstract:
-    "Now that your event or project has a code of conduct, how do you ensure it's effective? Are you prepared to deal with incident reporting and to resolve issues that come up? How can you tell if your code of conduct is actually working?
-    </p><p>
-    I'll draw on several years of experience working with code of conduct outreach and enforcement on open source projects, user groups, and a major conference to show you the steps to take to make sure your code of conduct is an effective tool for inclusion, safety, and building a stronger community.
-    </p><p>
-    We'll talk about reporting processes, documentation, creating a team or committee to handle reports, what responses are or aren't effective, and dealing with problems in the heat of the moment."
-  website: "http://lifeofaudrey.com"
-  video_url: "https://www.youtube.com/watch?v=nizfHxg8y3o"
-- name: "Bryan Liles"
-  headshot: "bryan-liles.png"
-  title: "Back in My Day..."
-  bio:
-    ""
-  abstract:
-    "Bryan Liles works on strategic initiatives for DigitalOcean. In layperson's terms, this means he writes open source software for DigitalOcean and others. He helps communities move their software to the public cloud, and gets to speak at conferences on topics ranging from machine learning to building the next generation of developers. When not thinking about code, Bryan races cars in straight lines and around turns, and builds robots and devices."
-  handle: "bryanl"
-  website: "http://blil.es"
-  video_url: "https://www.youtube.com/watch?v=8i0WQmZxzvo"
-- name: "Casey West"
-  headshot: "casey-west.jpg"
-  title: "How to be a Corporate Open Source Citizen"
-  bio:
-    "Casey West is a Principal Technologist for Cloud Foundry at Pivotal. Working in Internet infrastructure, web app security, and design taught him to be a paranoid, UX-oriented, problem solving Internet plumber. He’s spoken at events ranging from OSCON, ApacheCon, and YAPC to user groups and Geek Cruises, and writes occasionally for O’Reilly Radar. Topics of late include tech culture, devops, open source community, software architecture, platforms, and quirky programming tricks. Casey lives in Pittsburgh where he raises three sarcastic children and organizes #CoffeeOps, and his earliest contributions to Perl live to this day on your Mac. You can follow @caseywest on Twitter and read his blog at caseywest.com."
-  abstract:
-    "It's generally considered a good thing when companies open source their software. They're giving back to the community and being good citizens. Unfortunately it's not always the case that companies are good actors in our community. Sometimes they are bad actors, with practices including deceptive promises of open participation and exploiting free labor in the form of community contributions.
-    </p><p>
-    This talk explores patterns in company-sponsored open source projects, actions which influence the acceptability of those projects by the open source community, and opportunities for companies to participate wholeheartedly in the open source community. Let's talk about the patterns demonstrated by good corporate open source citizens."
-  website: "http://caseywest.com"
-  handle: "caseywest"
-  video_url: "https://www.youtube.com/watch?v=3PKTVFjCeXQ"
-- name: "Eric Holscher"
-  headshot: "eric-holscher.jpg"
-  title: "Documentation as Empathy"
-  bio:
-    "Eric Holscher is a founder of both Read the Docs and Write the Docs. When he isn't helping improve the documentation world, he's out in the woods somewhere."
-  abstract:
-    "This talk will cover my view of documentation within programming culture as it has grown over the years. As a primary person involved with Read the Docs (the largest open source doc hosting website) and Write the Docs (the largest OSS doc conference), I have seen a lot of angles, and appreciate documentation more every year.
-    </p><p>
-    I believe better documentation is a fundamental aspect of how we can improve programming culture, and an often misunderstood part of outreach and education. Projects with good documentation are able to get contributors in a much more reliable fashion, and, more importantly, projects without documentation only attract users who have time to waste.
-    </p><p>
-    This talk will make you think more deeply about the social impact of documentation, and hopefully make you question if it should be a higher priority in your development. You should understand the role of documentation in both technical as well as social realms."
-  handle: "ericholscher"
-  website: "http://ericholscher.com"
-  video_url: "https://www.youtube.com/watch?v=CvhJG_HfKac"
-- name: "Greg Tarnoff"
-  headshot: "greg-tarnoff.jpg"
-  title: "Designing with Empathy"
-  bio:
-    "Greg Tarnoff is a front end developer by day and accessibility hero all the time. For the last decade, he's focused on building products that work for all users."
-  abstract:
-    "Too often we get caught up in our own biases, even the most compassionate of us. When we do, we lose sight of how to design and build platforms and experiences that work for all our users. We end up building for ourselves, the person who knows the system inside and out, the power user. And while people like us are important, they rarely make up the majority of users.
-    </p><p>
-    We need to build things that anyone can learn quickly, use efficiently, making the user feel confident and powerful. Through examples of atypical users, I’ll walk through things to consider when designing tools and applications that empower the greatest number of users to achieve more."
-  handle: "gregtarnoff"
-  website: "http://tarnoff.info"
-  video_url: "https://www.youtube.com/watch?v=KtcM4l5qd4A"
-- name: "Hsing-Hui Hsu"
-  headshot: "Hsing-Hui-Hsu.jpg"
-  title: "To Feel or Not to Feel; That is the Question"
-  bio:
-    "Hsing-Hui Hsu is a graduate of the first cohort of Ada Developers Academy. She enjoys learning languages (both computer and human), playing ultimate frisbee, and rabbit-hole spelunking. Hsing-Hui currently works as a full-stack developer at CareZone."
-  abstract:
-    "In the tech industry, and especially in the open source community, there are many frustrations and problems that everyone experiences. It is no secret, however, that these problems are not evenly distributed. Those who tend to be underrepresented in the industry find their feelings of marginalization compounded by behavior that has come to be viewed as the norm.
-    </p><p>
-    And while it is also no secret that speaking out about these issues can in itself be a problem, it is not as simple as it seems. Will standing up to injustice harm your career? Are harassment and *-ism just something you should expect? Is there a certain initiation/hazing period that you have to simply suffer through before you can be taken seriously? Do certain marginalized subgroups have it worse than others, and what does that mean for those who don't have it the worst? In this talk, we'll take a deep dive into the many not-often-discussed nuances of a widely known problem."
-  handle: "SoManyHs"
-  video_url: "https://www.youtube.com/watch?v=9AH9CltVldY"
-- name: "Isaac Z. Schlueter"
-  headshot: "isaac-schlueter.jpg"
-  title: "Non-Violent Communication for Fun, Profit, and Self Defense"
-  bio:
-    "You might know Isaac Z. Schlueter from such open source software communities as Node.js and npm. Having transitioned from programming computers full time to managing people in the last few years, he's been pretty interested in feelings as well. Also he makes jokes on Twitter sometimes."
-  abstract:
-    "Managing open source projects exposes a maintainer to the vagaries of the internet. For all the joy and convenience that a bit of technology may bring to its users, users typically show up when they are in an unhappy place, and the job of the maintainer can quickly become an overwhelming source of stress and burnout.
-    </p><p>
-    This talk will introduce Non-Violent Communication as a toolkit for helping users at their worst, and also prevent the flood of bad vibes from becoming a source of toxicity. By exposing our vulnerability in a direct and honest way, we can turn conversations away from blame and antagonism, towards meaningful connection and opportunities for growth and collaboration. Open source is a social machine, and compassion helps keep the gears from grinding to a halt."
-  handle: "izs"
-  website: "http://blog.izs.me"
-  video_url: "https://www.youtube.com/watch?v=G5_8u3NA8M8"
-- name: "Jacob Kaplan-Moss"
-  headshot: "jkm.jpg"
-  title: "What Part of \"... for Life\" Don't You Understand?"
-  bio:
-    "In 2005 Jacob Kaplan-Moss joined the \"Lawrence Journal-World\", a locally owned newspaper in Lawrence, KS, and helped develop and eventually open source Django. He later founded the Django Software Foundation and served as its president for several terms. Today, Jacob is the director of security at Heroku."
-  abstract:
-    "When we released Django, we took our structure from the Python community, appointing Adrian Holovaty and me as \"Benevolent Dictators for Life\". Turns out, \"... for life\" is a pretty long time — who knew — and this role turned out not to be sustainable.
-    </p><p>
-    About a year and a half ago we resigned, and Django transitioned to a completely community-run project.
-    </p><p>
-    This is a story about this journey: how I became a BDFL, what worked and didn't about that, how I burnt out and \"retired\" — and what I've been doing in open source since."
-  website: "https://jacobian.org"
-  handle: "jacobian"
-  video_url: "https://www.youtube.com/watch?v=EqcuzSwySR4"
-- name: "Jen Myers"
-  headshot: "jen-myers.png"
-  title: "Listen to Your (and All) Mothers: How to Create Family-Inclusive Tech Communities"
-  bio:
-    "Jen Myers is a technologist, speaker, and writer from Chicago. She is also the director of open source curriculum at Pluralsight, founder of Code and Cupcakes Chicago, and a teacher/advisor with Girl Develop It."
-  abstract:
-    "For the past year in Chicago, I’ve been teaching beginning coding workshops for mothers and daughters. I began the series inspired by my own experiences teaching my daughter HTML, and, most importantly, as a single mother navigating a tech career, who knows firsthand that most tech communities are not designed with the needs of people like me in mind. And, yet, we’re out there, willing, capable and ready, trying to find our ways in anyway.
-    </p><p>
-    If we truly want to improve the diversity of our tech communities, we need to talk about how childcare responsibilities disproportionately affect the marginalized, and how to have more empathy for those with those responsibilities. Let’s talk about how to create successfully family-inclusive events, how to care for the carers, and how we can all work together to build a strong, open pathway for the next generation."
-  website: "http://jenmyers.net"
-  handle: "antiheroine"
-  video_url: "https://www.youtube.com/watch?v=Oj4NRtXDxKQ"
-- name: "Kat Toomajian"
-  headshot: "kat-toomajian.jpg"
-  title: "From the Inside Out: How Self-Talk Affects Your Community"
-  bio:
-    "Kat Toomajian works for Dreamwidth Studios as the head of support. She loves insurance, superheroes, historical hermeneutics, and bioethics, among other things. She lives in Minnesota with her two ferrets, Hermes and Isaac."
-  abstract:
-    "Identifying and discouraging negative self-talk is a simple thing, but it can have a huge impact on your community in a positive way. It increases self-confidence, improves morale, and generally results in happier, more productive community participants. This, in turn, will make you happy.
-    </p><p>
-    Negative self-talk is a pervasive, invasive, and unproductive way of thinking. It can trigger a cascade of things, from abandoned patches (“I am not smart/talented/good enough to figure this out”), to withdrawl from the community (“I screwed this up and everyone knows and hates me”), to general discouragement (“I suck, and have nothing valuable to contribute here”).
-    </p><p>
-    In this talk, I’ll discuss the various methods Dreamwidth and other organizations use to handle negative self-talk, and the best way to deploy those techniques. I will also discuss things to keep an eye out for in your community that may be at the root of this type of self-talk, and processes you can go through to eliminate them. Finally, there will be a quick overview of impostor syndrome, and the role it plays here."
-  website: "http://misskat.dreamwidth.org"
-  handle: "zarhooie"
-  video_url: "https://www.youtube.com/watch?v=T4tjF1cTy8A"
-- name: "Lauren D. Voswinkel"
-  headshot: "Lauren-Voswinkel.png"
-  title: "Let's Continue to Talk About Pay"
-  bio:
-    "Lauren D. Voswinkel has spoken at numerous conferences, including, GoRuCo 2013; Ruby Nation 2013: Open Source Bridge 2014, 2015; Madison Ruby 2014; RubyConf AU 2015; and soon AlterConf Toronto.
-    </p><p>
-    She has also acted as a speaking mentor at Write/Speak/Code"
-  abstract:
-    "On International Workers' Day I asked the world to #talkpay, and many people did. Pay transparency is critical in order to address pay inequity in our field, as well as others, but there's more to it than that. I'd like to discuss why this taboo surrounding pay got started, illustrate just how concerted of an effort there is to prevent workers (including tech workers) from pushing for higher pay, and why, exactly, we NEED to talk about pay."
-  handle: "laurenvoswinkel"
-  video_url: "https://www.youtube.com/watch?v=54XU1WZKWKI"
-- name: "Rachel Ober"
-  headshot: "rachel-ober.jpg"
-  title: "Ensuring the Sustainability of Your Code Learning Community"
-  bio:
-    "Rachel Ober is a software engineer in Brooklyn, NY, specializing in developing in Sass, Ruby, and Ruby on Rails. She spends a lot of
-    time learning new things in technology and loves sharing it with others."
-  abstract:
-    "Most great epics tell of how against all odds, our heroine champions over incredible hurdles to accomplish their dream and create a massively successful project. I'm here to tell you that the story isn't over after the happily ever after. Instead, the hard work is just beginning.
-    </p><p>
-    True legends don't form from one successful deploy, or one successful workshop run. Success is dictated by longevity and key points of interest.
-    </p><p>
-    Now that you've figured out and climbed your mountain, how are you going to keep your project alive? How can you ensure stability?
-    </p><p>
-    In 2013, I set out with a very manageable goal of running a RailsBridge workshop in New York City. The second part of my goal was to create a self-sustaining organization that would continue to run workshops to teach the underrepresented minorities in tech while keeping the values set by the RailsBridge founders Sarah Mei and Sarah Allen.
-    </p><p>
-    It's easy to run workshops, it's a lot harder to develop a healthy culture within a volunteer organization.
-    </p><p>
-    In this talk I will highlight key points from my two years as a RailsBridge chapter founder and go through the challenges I faced through strategies in real-time communication, documentation, and code curriculum sharing through technology."
-  handle: "rachelober"
-  website: "http://rachelober.com"
-  video_url: "https://www.youtube.com/watch?v=jYM8AnreZHQ"
-- name: "Stephanie Morillo"
-  headshot: "Stephanie-Morillo.jpg"
-  title: "Creating A Space For Us: How A Twitter Chat Turned Into A Virtual Community For #WOCinTech"
-  bio:
-    "Stephanie Morillo is a Dominican-American musician, writer, and technologist hailing from the Bronx, New York City. She frequently writes about class, race, her experiences learning to code, and working in tech. She is the cofounder of #WOCinTech Chat and a copywriter at DigitalOcean. She enjoys helping others learn to program, singing melancholic songs, and dreaming about well-written documentation because the world needs it."
-  abstract:
-    "I've heard it before from people in positions of privilege - \"If you don't feel represented, then why don't you create something of your own?\" After more than two-and-a-half years working in the tech industry, I always felt that living on the intersection of race and gender were seldom addressed in tech initiatives, and in work spaces I seldom encountered other professional women of color outside of the service staff.
-    </p><p>
-    In an effort to get over the feelings of isolation, a friend and I created a Twitter chat using the then-underused #WOCinTech hashtag in an effort to bridge the geographic and workplace barriers and connect with women of color already in the tech industry and connect with each other.
-    </p><p>
-    The chat has since grown to become a full-fledged community made up of women of color and nonbinary POC technologists, and our two-person team has responded to the needs of this community by creating initiatives that target these groups specifically.
-    </p><p>
-    In my talk, I'll discuss my experiences living at the intersection of race and gender, the #WOCinTech chat origin story, how connecting with women of color has empowered me professionally, and how the community wants to help others on their path to a career in tech."
-  handle: "radiomorillo"
-  video_url: "https://www.youtube.com/watch?v=hW1lsSqU_Uc"
-- name: "Taylor Dewey"
-  headshot: "Taylor-Dewey.jpg"
-  title: "A cry for help: What Answering 911 Teaches Us About Building Better Software"
-  bio:
-    ""
-  abstract:
-    "\"911, what is your emergency?\" is the question that starts every call. My job, for three years, was to negotiate the caller's emotional minefield to gain life-saving information and insight.
-    </p><p>
-    In this story-centric talk, I show how working in software and with open source communities is similar to emergency services.
-    </p><p>
-    Participants will hear stories that reveal human nature and understand some of the system and training that creates order from emotional chaos. UX designers and software developers can use these same techniques to uncover their users' needs, manage volunteers, communicate effectively, and prioritize development.
-    </p><p>
-    <strong class='pink'>Trigger warning:</strong> in this talk I plan on telling stories from my 911 calltaker perspective of real or attempted missing persons, homicide, and suicide calls. Weapons are mentioned."
-  handle: "tddewey"
-  video_url: "https://www.youtube.com/watch?v=KkWcAQBLJqA"
-- name: "Tute Costa"
-  headshot: "tute-costa.jpeg"
-  title: "Welcoming People (and Other Hard Problems)"
-  bio:
-    "Tute Costa studied Computer Sciences in Argentina, worked on and contributed to different open source projects, and now works at thoughtbot NYC. He released a beta version of the book \"Maintaining Open Source Projects\", where he covers mainly the non-technical aspects of the job."
-  abstract:
-    "We interact with people in chat rooms, issue trackers, pull requests, discussion boards, meetups, hallways, or conferences.
-    </p><p>
-    How do we provide feedback constructively? Are we perceived as friendly as we think we are? How exactly do our cognitive biases unconsciously affect our human interactions? How do we become conscious of them? What assumptions does our language carry?
-    </p><p>
-    Effective communication is critical particularly for project leaders. As leaders, we open the doors to our gardens, and the first interactions define the tone for the group, shaping today's atmosphere as much as tomorrow's. In this talk, we'll explore how to communicate effectively. Always, and with everyone."
-  website: "http://www.tutecosta.com/software-developer/"
-  handle: "tutec"
-  video_url: "https://www.youtube.com/watch?v=EahvHpQFcss"
-- name: "Mariko Kosaka"
-  headshot: "mariko-kosaka.jpg"
-  title: "Re-inventing the Rosetta Stone Together"
-  bio:
-    "Mariko Kosaka is a software engineer who loves data and knitting. When she is not coding applications for other people, she uses code to help her design textiles, and organize local meetup BrooklynJS."
-  abstract:
-    "Many tech projects are anglocentric. The de facto language used to develop and document a project is English, and it is often overlooked that a project is used largely by non-English speaking communities.
-    </p><p>
-    We programmers like to think \"code is the universal language,\" but getting to speak code still involves overcoming language barriers. Even after you speak code, your experience working on project involves a lot of cultural references and language use specific to English. So let's pause for a moment talking about the newest features and technical specs, look at the experience of a silent majority, and talk about how we can welcome them to your project today!"
-  website: "http://kosamari.com"
-  handle: "kosamari"
-  video_url: "https://www.youtube.com/watch?v=OOzAly5Rs7g"
-- name: "Cindy Pallares Quezada"
-  headshot: "cindy-pallares.jpg"
-  title: "When Free Culture isn't Free: The Price of Cultural Appropriation on Communities of Color"
-  bio:
-    "Cindy Pallares is a student, activist, part-time Red Hatter, and member of Free Culture Foundation. She is passionate about free software and free culture and spends her time doing outreach and volunteering to get more people involved in open source software. "
-  abstract:
-    "When we speak about free and open source and culture, we often speak about the ability to share, modify, and distribute content. The socially and economically privileged, however, have often used the free exchange of ideas to create a great deal of profit, continually taking from those with little social or economic power without permission or acknowledgment.
-    </p><p>
-    These appropriated ideas are reduced to commodities and stripped of their cultural roots, which are deemed inferior. In this talk, we will discuss some pitfalls in the discourse around free culture, understand the difference between authentic cultural exchange and appropriation, and discuss the steps we can do to acknowledge and prevent cultural appropriation."
-  website: "http://cpallar.es"
-  handle: "cindy_pallares"
+- year: 2015
+  speakers:
+  - name: "Al Nelson"
+    headshot: "al-nelson.png"
+    title: "What Roleplaying Games Can Teach Us About Open Source Communities"
+    bio:
+      "Al Nelson is a writer of both code and words and finds joy in combining the two. They write documentation for Alpine Data Labs by day and tell stories through novels and games by night."
+    abstract:
+      "In games, a valuable team is made up of characters with varied talents and skills. They need to be adaptable, to communicate, and most of all, to work together. As a team, they can accomplish even the most intimidating quests. It's time we took this mentality to the open source community.
+      </p><p>
+      Roleplaying games can teach us a lot about diversity and working as a team if we dig a little deeper. In such games, players take on the role of a fantasy character and participate in quests and adventures with a group of other players. During this talk, I will take popular fantasy classes and relate them to the variety of people who contribute to open source communities every day.
+      </p><p>
+      Just like a roleplaying party would fail with only type of character, open source needs the unsung heroes: the technical writers, the artists, the testers—to make the project a reality. By building our 'party' around diverse interests and welcoming newcomers with open arms, open source communities can prosper."
+    handle: "musegarden"
+    video_url: "https://www.youtube.com/watch?v=Yk57XV_bbPY"
+  - name: "Alex Harms"
+    headshot: "alex-harms.jpg"
+    title: "Learning to Empathy"
+    bio:
+      "Alex Harms helps teams thrive by encouraging mindfulness and facilitating trust and openness. The result is improved communication, better technical decisions, and renewed joy in their working environment and codebase."
+    abstract:
+      "You've heard empathy is a learned skill. Let's really talk about it. What does it mean to have empathy? Why does it matter, anyway? And if empathy is useful (I hope to show you how it is), how do you get better at it?
+      </p><p>
+      In this session, you'll learn real stuff about what's in your own heart, and how to connect to the people you encounter. Less feeling shitty, more enjoying projects!"
+    video_url: "https://www.youtube.com/watch?v=U15nkcSY2GI"
+  - name: "Audrey Eschright"
+    headshot: "audrey-eschright.jpg"
+    title: "Enforcing Your Code of Conduct: Effective Incident Response"
+    bio:
+      "Audrey Eschright is a software developer, community organizer, and activist based in Portland, OR. She produces The Recompiler, a feminist hacker magazine; founded Calagator, an open source community calendaring service; and co-founded Open Source Bridge, an annual conference for open source citizens."
+    abstract:
+      "Now that your event or project has a code of conduct, how do you ensure it's effective? Are you prepared to deal with incident reporting and to resolve issues that come up? How can you tell if your code of conduct is actually working?
+      </p><p>
+      I'll draw on several years of experience working with code of conduct outreach and enforcement on open source projects, user groups, and a major conference to show you the steps to take to make sure your code of conduct is an effective tool for inclusion, safety, and building a stronger community.
+      </p><p>
+      We'll talk about reporting processes, documentation, creating a team or committee to handle reports, what responses are or aren't effective, and dealing with problems in the heat of the moment."
+    website: "http://lifeofaudrey.com"
+    video_url: "https://www.youtube.com/watch?v=nizfHxg8y3o"
+  - name: "Bryan Liles"
+    headshot: "bryan-liles.png"
+    title: "Back in My Day..."
+    bio:
+      ""
+    abstract:
+      "Bryan Liles works on strategic initiatives for DigitalOcean. In layperson's terms, this means he writes open source software for DigitalOcean and others. He helps communities move their software to the public cloud, and gets to speak at conferences on topics ranging from machine learning to building the next generation of developers. When not thinking about code, Bryan races cars in straight lines and around turns, and builds robots and devices."
+    handle: "bryanl"
+    website: "http://blil.es"
+    video_url: "https://www.youtube.com/watch?v=8i0WQmZxzvo"
+  - name: "Casey West"
+    headshot: "casey-west.jpg"
+    title: "How to be a Corporate Open Source Citizen"
+    bio:
+      "Casey West is a Principal Technologist for Cloud Foundry at Pivotal. Working in Internet infrastructure, web app security, and design taught him to be a paranoid, UX-oriented, problem solving Internet plumber. He’s spoken at events ranging from OSCON, ApacheCon, and YAPC to user groups and Geek Cruises, and writes occasionally for O’Reilly Radar. Topics of late include tech culture, devops, open source community, software architecture, platforms, and quirky programming tricks. Casey lives in Pittsburgh where he raises three sarcastic children and organizes #CoffeeOps, and his earliest contributions to Perl live to this day on your Mac. You can follow @caseywest on Twitter and read his blog at caseywest.com."
+    abstract:
+      "It's generally considered a good thing when companies open source their software. They're giving back to the community and being good citizens. Unfortunately it's not always the case that companies are good actors in our community. Sometimes they are bad actors, with practices including deceptive promises of open participation and exploiting free labor in the form of community contributions.
+      </p><p>
+      This talk explores patterns in company-sponsored open source projects, actions which influence the acceptability of those projects by the open source community, and opportunities for companies to participate wholeheartedly in the open source community. Let's talk about the patterns demonstrated by good corporate open source citizens."
+    website: "http://caseywest.com"
+    handle: "caseywest"
+    video_url: "https://www.youtube.com/watch?v=3PKTVFjCeXQ"
+  - name: "Eric Holscher"
+    headshot: "eric-holscher.jpg"
+    title: "Documentation as Empathy"
+    bio:
+      "Eric Holscher is a founder of both Read the Docs and Write the Docs. When he isn't helping improve the documentation world, he's out in the woods somewhere."
+    abstract:
+      "This talk will cover my view of documentation within programming culture as it has grown over the years. As a primary person involved with Read the Docs (the largest open source doc hosting website) and Write the Docs (the largest OSS doc conference), I have seen a lot of angles, and appreciate documentation more every year.
+      </p><p>
+      I believe better documentation is a fundamental aspect of how we can improve programming culture, and an often misunderstood part of outreach and education. Projects with good documentation are able to get contributors in a much more reliable fashion, and, more importantly, projects without documentation only attract users who have time to waste.
+      </p><p>
+      This talk will make you think more deeply about the social impact of documentation, and hopefully make you question if it should be a higher priority in your development. You should understand the role of documentation in both technical as well as social realms."
+    handle: "ericholscher"
+    website: "http://ericholscher.com"
+    video_url: "https://www.youtube.com/watch?v=CvhJG_HfKac"
+  - name: "Greg Tarnoff"
+    headshot: "greg-tarnoff.jpg"
+    title: "Designing with Empathy"
+    bio:
+      "Greg Tarnoff is a front end developer by day and accessibility hero all the time. For the last decade, he's focused on building products that work for all users."
+    abstract:
+      "Too often we get caught up in our own biases, even the most compassionate of us. When we do, we lose sight of how to design and build platforms and experiences that work for all our users. We end up building for ourselves, the person who knows the system inside and out, the power user. And while people like us are important, they rarely make up the majority of users.
+      </p><p>
+      We need to build things that anyone can learn quickly, use efficiently, making the user feel confident and powerful. Through examples of atypical users, I’ll walk through things to consider when designing tools and applications that empower the greatest number of users to achieve more."
+    handle: "gregtarnoff"
+    website: "http://tarnoff.info"
+    video_url: "https://www.youtube.com/watch?v=KtcM4l5qd4A"
+  - name: "Hsing-Hui Hsu"
+    headshot: "Hsing-Hui-Hsu.jpg"
+    title: "To Feel or Not to Feel; That is the Question"
+    bio:
+      "Hsing-Hui Hsu is a graduate of the first cohort of Ada Developers Academy. She enjoys learning languages (both computer and human), playing ultimate frisbee, and rabbit-hole spelunking. Hsing-Hui currently works as a full-stack developer at CareZone."
+    abstract:
+      "In the tech industry, and especially in the open source community, there are many frustrations and problems that everyone experiences. It is no secret, however, that these problems are not evenly distributed. Those who tend to be underrepresented in the industry find their feelings of marginalization compounded by behavior that has come to be viewed as the norm.
+      </p><p>
+      And while it is also no secret that speaking out about these issues can in itself be a problem, it is not as simple as it seems. Will standing up to injustice harm your career? Are harassment and *-ism just something you should expect? Is there a certain initiation/hazing period that you have to simply suffer through before you can be taken seriously? Do certain marginalized subgroups have it worse than others, and what does that mean for those who don't have it the worst? In this talk, we'll take a deep dive into the many not-often-discussed nuances of a widely known problem."
+    handle: "SoManyHs"
+    video_url: "https://www.youtube.com/watch?v=9AH9CltVldY"
+  - name: "Isaac Z. Schlueter"
+    headshot: "isaac-schlueter.jpg"
+    title: "Non-Violent Communication for Fun, Profit, and Self Defense"
+    bio:
+      "You might know Isaac Z. Schlueter from such open source software communities as Node.js and npm. Having transitioned from programming computers full time to managing people in the last few years, he's been pretty interested in feelings as well. Also he makes jokes on Twitter sometimes."
+    abstract:
+      "Managing open source projects exposes a maintainer to the vagaries of the internet. For all the joy and convenience that a bit of technology may bring to its users, users typically show up when they are in an unhappy place, and the job of the maintainer can quickly become an overwhelming source of stress and burnout.
+      </p><p>
+      This talk will introduce Non-Violent Communication as a toolkit for helping users at their worst, and also prevent the flood of bad vibes from becoming a source of toxicity. By exposing our vulnerability in a direct and honest way, we can turn conversations away from blame and antagonism, towards meaningful connection and opportunities for growth and collaboration. Open source is a social machine, and compassion helps keep the gears from grinding to a halt."
+    handle: "izs"
+    website: "http://blog.izs.me"
+    video_url: "https://www.youtube.com/watch?v=G5_8u3NA8M8"
+  - name: "Jacob Kaplan-Moss"
+    headshot: "jkm.jpg"
+    title: "What Part of \"... for Life\" Don't You Understand?"
+    bio:
+      "In 2005 Jacob Kaplan-Moss joined the \"Lawrence Journal-World\", a locally owned newspaper in Lawrence, KS, and helped develop and eventually open source Django. He later founded the Django Software Foundation and served as its president for several terms. Today, Jacob is the director of security at Heroku."
+    abstract:
+      "When we released Django, we took our structure from the Python community, appointing Adrian Holovaty and me as \"Benevolent Dictators for Life\". Turns out, \"... for life\" is a pretty long time — who knew — and this role turned out not to be sustainable.
+      </p><p>
+      About a year and a half ago we resigned, and Django transitioned to a completely community-run project.
+      </p><p>
+      This is a story about this journey: how I became a BDFL, what worked and didn't about that, how I burnt out and \"retired\" — and what I've been doing in open source since."
+    website: "https://jacobian.org"
+    handle: "jacobian"
+    video_url: "https://www.youtube.com/watch?v=EqcuzSwySR4"
+  - name: "Jen Myers"
+    headshot: "jen-myers.png"
+    title: "Listen to Your (and All) Mothers: How to Create Family-Inclusive Tech Communities"
+    bio:
+      "Jen Myers is a technologist, speaker, and writer from Chicago. She is also the director of open source curriculum at Pluralsight, founder of Code and Cupcakes Chicago, and a teacher/advisor with Girl Develop It."
+    abstract:
+      "For the past year in Chicago, I’ve been teaching beginning coding workshops for mothers and daughters. I began the series inspired by my own experiences teaching my daughter HTML, and, most importantly, as a single mother navigating a tech career, who knows firsthand that most tech communities are not designed with the needs of people like me in mind. And, yet, we’re out there, willing, capable and ready, trying to find our ways in anyway.
+      </p><p>
+      If we truly want to improve the diversity of our tech communities, we need to talk about how childcare responsibilities disproportionately affect the marginalized, and how to have more empathy for those with those responsibilities. Let’s talk about how to create successfully family-inclusive events, how to care for the carers, and how we can all work together to build a strong, open pathway for the next generation."
+    website: "http://jenmyers.net"
+    handle: "antiheroine"
+    video_url: "https://www.youtube.com/watch?v=Oj4NRtXDxKQ"
+  - name: "Kat Toomajian"
+    headshot: "kat-toomajian.jpg"
+    title: "From the Inside Out: How Self-Talk Affects Your Community"
+    bio:
+      "Kat Toomajian works for Dreamwidth Studios as the head of support. She loves insurance, superheroes, historical hermeneutics, and bioethics, among other things. She lives in Minnesota with her two ferrets, Hermes and Isaac."
+    abstract:
+      "Identifying and discouraging negative self-talk is a simple thing, but it can have a huge impact on your community in a positive way. It increases self-confidence, improves morale, and generally results in happier, more productive community participants. This, in turn, will make you happy.
+      </p><p>
+      Negative self-talk is a pervasive, invasive, and unproductive way of thinking. It can trigger a cascade of things, from abandoned patches (“I am not smart/talented/good enough to figure this out”), to withdrawl from the community (“I screwed this up and everyone knows and hates me”), to general discouragement (“I suck, and have nothing valuable to contribute here”).
+      </p><p>
+      In this talk, I’ll discuss the various methods Dreamwidth and other organizations use to handle negative self-talk, and the best way to deploy those techniques. I will also discuss things to keep an eye out for in your community that may be at the root of this type of self-talk, and processes you can go through to eliminate them. Finally, there will be a quick overview of impostor syndrome, and the role it plays here."
+    website: "http://misskat.dreamwidth.org"
+    handle: "zarhooie"
+    video_url: "https://www.youtube.com/watch?v=T4tjF1cTy8A"
+  - name: "Lauren D. Voswinkel"
+    headshot: "Lauren-Voswinkel.png"
+    title: "Let's Continue to Talk About Pay"
+    bio:
+      "Lauren D. Voswinkel has spoken at numerous conferences, including, GoRuCo 2013; Ruby Nation 2013: Open Source Bridge 2014, 2015; Madison Ruby 2014; RubyConf AU 2015; and soon AlterConf Toronto.
+      </p><p>
+      She has also acted as a speaking mentor at Write/Speak/Code"
+    abstract:
+      "On International Workers' Day I asked the world to #talkpay, and many people did. Pay transparency is critical in order to address pay inequity in our field, as well as others, but there's more to it than that. I'd like to discuss why this taboo surrounding pay got started, illustrate just how concerted of an effort there is to prevent workers (including tech workers) from pushing for higher pay, and why, exactly, we NEED to talk about pay."
+    handle: "laurenvoswinkel"
+    video_url: "https://www.youtube.com/watch?v=54XU1WZKWKI"
+  - name: "Rachel Ober"
+    headshot: "rachel-ober.jpg"
+    title: "Ensuring the Sustainability of Your Code Learning Community"
+    bio:
+      "Rachel Ober is a software engineer in Brooklyn, NY, specializing in developing in Sass, Ruby, and Ruby on Rails. She spends a lot of
+      time learning new things in technology and loves sharing it with others."
+    abstract:
+      "Most great epics tell of how against all odds, our heroine champions over incredible hurdles to accomplish their dream and create a massively successful project. I'm here to tell you that the story isn't over after the happily ever after. Instead, the hard work is just beginning.
+      </p><p>
+      True legends don't form from one successful deploy, or one successful workshop run. Success is dictated by longevity and key points of interest.
+      </p><p>
+      Now that you've figured out and climbed your mountain, how are you going to keep your project alive? How can you ensure stability?
+      </p><p>
+      In 2013, I set out with a very manageable goal of running a RailsBridge workshop in New York City. The second part of my goal was to create a self-sustaining organization that would continue to run workshops to teach the underrepresented minorities in tech while keeping the values set by the RailsBridge founders Sarah Mei and Sarah Allen.
+      </p><p>
+      It's easy to run workshops, it's a lot harder to develop a healthy culture within a volunteer organization.
+      </p><p>
+      In this talk I will highlight key points from my two years as a RailsBridge chapter founder and go through the challenges I faced through strategies in real-time communication, documentation, and code curriculum sharing through technology."
+    handle: "rachelober"
+    website: "http://rachelober.com"
+    video_url: "https://www.youtube.com/watch?v=jYM8AnreZHQ"
+  - name: "Stephanie Morillo"
+    headshot: "Stephanie-Morillo.jpg"
+    title: "Creating A Space For Us: How A Twitter Chat Turned Into A Virtual Community For #WOCinTech"
+    bio:
+      "Stephanie Morillo is a Dominican-American musician, writer, and technologist hailing from the Bronx, New York City. She frequently writes about class, race, her experiences learning to code, and working in tech. She is the cofounder of #WOCinTech Chat and a copywriter at DigitalOcean. She enjoys helping others learn to program, singing melancholic songs, and dreaming about well-written documentation because the world needs it."
+    abstract:
+      "I've heard it before from people in positions of privilege - \"If you don't feel represented, then why don't you create something of your own?\" After more than two-and-a-half years working in the tech industry, I always felt that living on the intersection of race and gender were seldom addressed in tech initiatives, and in work spaces I seldom encountered other professional women of color outside of the service staff.
+      </p><p>
+      In an effort to get over the feelings of isolation, a friend and I created a Twitter chat using the then-underused #WOCinTech hashtag in an effort to bridge the geographic and workplace barriers and connect with women of color already in the tech industry and connect with each other.
+      </p><p>
+      The chat has since grown to become a full-fledged community made up of women of color and nonbinary POC technologists, and our two-person team has responded to the needs of this community by creating initiatives that target these groups specifically.
+      </p><p>
+      In my talk, I'll discuss my experiences living at the intersection of race and gender, the #WOCinTech chat origin story, how connecting with women of color has empowered me professionally, and how the community wants to help others on their path to a career in tech."
+    handle: "radiomorillo"
+    video_url: "https://www.youtube.com/watch?v=hW1lsSqU_Uc"
+  - name: "Taylor Dewey"
+    headshot: "Taylor-Dewey.jpg"
+    title: "A cry for help: What Answering 911 Teaches Us About Building Better Software"
+    bio:
+      ""
+    abstract:
+      "\"911, what is your emergency?\" is the question that starts every call. My job, for three years, was to negotiate the caller's emotional minefield to gain life-saving information and insight.
+      </p><p>
+      In this story-centric talk, I show how working in software and with open source communities is similar to emergency services.
+      </p><p>
+      Participants will hear stories that reveal human nature and understand some of the system and training that creates order from emotional chaos. UX designers and software developers can use these same techniques to uncover their users' needs, manage volunteers, communicate effectively, and prioritize development.
+      </p><p>
+      <strong class='pink'>Trigger warning:</strong> in this talk I plan on telling stories from my 911 calltaker perspective of real or attempted missing persons, homicide, and suicide calls. Weapons are mentioned."
+    handle: "tddewey"
+    video_url: "https://www.youtube.com/watch?v=KkWcAQBLJqA"
+  - name: "Tute Costa"
+    headshot: "tute-costa.jpeg"
+    title: "Welcoming People (and Other Hard Problems)"
+    bio:
+      "Tute Costa studied Computer Sciences in Argentina, worked on and contributed to different open source projects, and now works at thoughtbot NYC. He released a beta version of the book \"Maintaining Open Source Projects\", where he covers mainly the non-technical aspects of the job."
+    abstract:
+      "We interact with people in chat rooms, issue trackers, pull requests, discussion boards, meetups, hallways, or conferences.
+      </p><p>
+      How do we provide feedback constructively? Are we perceived as friendly as we think we are? How exactly do our cognitive biases unconsciously affect our human interactions? How do we become conscious of them? What assumptions does our language carry?
+      </p><p>
+      Effective communication is critical particularly for project leaders. As leaders, we open the doors to our gardens, and the first interactions define the tone for the group, shaping today's atmosphere as much as tomorrow's. In this talk, we'll explore how to communicate effectively. Always, and with everyone."
+    website: "http://www.tutecosta.com/software-developer/"
+    handle: "tutec"
+    video_url: "https://www.youtube.com/watch?v=EahvHpQFcss"
+  - name: "Mariko Kosaka"
+    headshot: "mariko-kosaka.jpg"
+    title: "Re-inventing the Rosetta Stone Together"
+    bio:
+      "Mariko Kosaka is a software engineer who loves data and knitting. When she is not coding applications for other people, she uses code to help her design textiles, and organize local meetup BrooklynJS."
+    abstract:
+      "Many tech projects are anglocentric. The de facto language used to develop and document a project is English, and it is often overlooked that a project is used largely by non-English speaking communities.
+      </p><p>
+      We programmers like to think \"code is the universal language,\" but getting to speak code still involves overcoming language barriers. Even after you speak code, your experience working on project involves a lot of cultural references and language use specific to English. So let's pause for a moment talking about the newest features and technical specs, look at the experience of a silent majority, and talk about how we can welcome them to your project today!"
+    website: "http://kosamari.com"
+    handle: "kosamari"
+    video_url: "https://www.youtube.com/watch?v=OOzAly5Rs7g"
+  - name: "Cindy Pallares Quezada"
+    headshot: "cindy-pallares.jpg"
+    title: "When Free Culture isn't Free: The Price of Cultural Appropriation on Communities of Color"
+    bio:
+      "Cindy Pallares is a student, activist, part-time Red Hatter, and member of Free Culture Foundation. She is passionate about free software and free culture and spends her time doing outreach and volunteering to get more people involved in open source software. "
+    abstract:
+      "When we speak about free and open source and culture, we often speak about the ability to share, modify, and distribute content. The socially and economically privileged, however, have often used the free exchange of ideas to create a great deal of profit, continually taking from those with little social or economic power without permission or acknowledgment.
+      </p><p>
+      These appropriated ideas are reduced to commodities and stripped of their cultural roots, which are deemed inferior. In this talk, we will discuss some pitfalls in the discourse around free culture, understand the difference between authentic cultural exchange and appropriation, and discuss the steps we can do to acknowledge and prevent cultural appropriation."
+    website: "http://cpallar.es"
+    handle: "cindy_pallares"

--- a/source/individual_speaker.html.haml
+++ b/source/individual_speaker.html.haml
@@ -1,0 +1,19 @@
+.row.callouts.confetti.confetti--heart
+  .col-md-8.col-md-offset-2.individual-speaker.speakers--info
+    %h2.purple= "#{speaker[:name]}"
+    .speakers--info-box
+      %img{ src: "/images/presenters/#{ speaker[:headshot]}", alt: speaker[:name] }
+      %h3.speakers--title.text-left= speaker[:title]
+    .speakers--abstract
+      %p= speaker[:abstract]
+    - if speaker[:bio] != ""
+      .speakers--bio
+        %h4.text-left Speaker Bio
+        %p= speaker[:bio]
+    .speakers--contact
+      - if speaker[:handle]
+        %a.confetti.confetti--inline.confetti--sm.confetti--heart{ href: "http://twitter.com/#{ speaker[:handle] }", target: "_blank" }= "@#{ speaker["handle"] }"
+      - if speaker[:website]
+        %a.confetti.confetti--inline.confetti--sm.confetti--speech{ href: speaker[:website], target: "_blank" } Website
+      - if speaker[:video_url]
+        %a.confetti.confetti--inline.confetti--sm.confetti--smile{ href: speaker[:video_url], target: "_blank" } Video of Talk

--- a/source/previous-speakers.html.haml
+++ b/source/previous-speakers.html.haml
@@ -1,26 +1,11 @@
 .row.page--title.confetti.confetti--smile
   .col-md-8.col-md-offset-2
     %h1.pink Previous Speakers
-    %p Thanks to all of our amazing speakers who presented at the first edition of OS Feels in 2015!
+    %p Thanks to all of the amazing speakers who have presented at OS Feels! Click a speaker's name to view talk descriptions, speaker information, and video links.
 
-.row
-  - data.previous_speakers.each do |speaker|
-    .col-md-6.speakers--info
-      %a{ name: generate_slug(speaker["name"]) }
-      .speakers--info-box
-        %img.speakers--img.img-rounded{ src: "/images/presenters/#{ speaker["headshot"] }", alt: speaker["name"] }
-        %h2.speakers--name= speaker["name"]
-        %h3.speakers--title.text-left= speaker["title"]
-      .speakers--abstract
-        %p= speaker["abstract"]
-      - if speaker["bio"] != ""
-        .speakers--bio
-          %h4.text-left Speaker Bio
-          %p= speaker["bio"]
-      .speakers--contact
-        - if speaker["handle"]
-          %a.confetti.confetti--inline.confetti--sm.confetti--heart{ href: "http://twitter.com/#{ speaker["handle"] }", target: "_blank" }= "@#{ speaker["handle"] }"
-        - if speaker["website"]
-          %a.confetti.confetti--inline.confetti--sm.confetti--speech{ href: speaker["website"], target: "_blank" } Website
-        - if speaker["video_url"]
-          %a.confetti.confetti--inline.confetti--sm.confetti--smile{ href: speaker["video_url"], target: "_blank" } Video of Talk
+- data.previous_speakers.each do |conference|
+  .row.confetti.confetti--heart
+    %h2.blue 2015
+    - conference[:speakers].each do |speaker|
+      .col-md-8.col-md-offset-2
+        %p.text-center=link_to speaker[:name], "/previous-speakers/#{conference[:year]}/#{generate_slug(speaker[:name])}"

--- a/source/stylesheets/override.css
+++ b/source/stylesheets/override.css
@@ -414,6 +414,17 @@ p a {
   display: block;
 }
 
+.individual-speaker img {
+  width: 40%;
+  float: left;
+  margin-right: 15px;
+}
+
+.individual-speaker .speakers--info-box {
+  min-height: 0;
+  margin-bottom: 0;
+}
+
 
 /* --- Schedule Page */
 .event--day h2 {


### PR DESCRIPTION
This PR will hopefully make it easier to maintain previous speakers in future years by:
- Generating individual dynamic speaker pages, organized by year (i.e. `/previous-speakers/<year>/<speaker-name>`)
- Updating `/previous-speakers` to list links to speaker individual pages