### PR TITLE
Updated public transit information to say the Capitol Hill station is…

### DIFF
--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -29,7 +29,7 @@
     %h2.blue How to Get Here
     .purple
       %h3 Public Transportation
-      %p Metro buses 9, 10, 11, 43, 49, 60, and 84 all have stops within a block of the venue. The venue is also a 20 minute, up hill walk from Westlake, the LightRail's last stop.
+      %p Metro buses 9, 10, 11, 43, 49, 60, and 84 all have stops within a block of the venue. The venue is also a 5 minute walk from the LightRail's Capitol Hill station.
       %p
         The
         %a.pink{ href: "http://tripplanner.kingcounty.gov/", target: "_blank" } King County Trip Planner


### PR DESCRIPTION
… the closest light rail station