### PR TITLE
There was email confusion about the listed sponsors (2015 or 2016?) 

### DIFF
--- a/source/sponsors.html.haml
+++ b/source/sponsors.html.haml
@@ -5,7 +5,7 @@
 
 .row.page--title.confetti.confetti--heart
   .col-md-8.col-md-offset-2
-    %h1.blue Thank You to Our Sponsors!
+    %h1.blue Thank You to Our 2016 Conference Sponsors!
     %p Open Source & Feelings wouldn't be possible without the support of our wonderful sponsors.
 
 .sponsors--level.callouts.confetti.confetti--lightning


### PR DESCRIPTION
...So I've added year information to clarify the page.